### PR TITLE
Provide the menu as a module

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,7 +48,8 @@ def menugen(screen, entries):
     brightness = 7
     pew.brightness(brightness)
     selected = 0
-    pix = pew.Pix.from_text(entries[selected])
+    selectedText = entries[selected]
+    pix = pew.Pix.from_text(selectedText)
     x = 0
     animation = scroll(screen, pix)
     while True:
@@ -63,7 +64,8 @@ def menugen(screen, entries):
             pew.brightness(brightness)
         if keys & pew.K_UP:
             selected = (selected - 1) % len(entries)
-            next_pix = pew.Pix.from_text(entries[selected])
+            selectedText = entries[selected]
+            next_pix = pew.Pix.from_text(selectedText)
             yield from change(screen, pix, next_pix, x, 1)
             hold_keys()
             pix = next_pix
@@ -71,7 +73,8 @@ def menugen(screen, entries):
             keys = 0
         if keys & pew.K_DOWN:
             selected = (selected + 1) % len(entries)
-            next_pix = pew.Pix.from_text(entries[selected])
+            selectedText = entries[selected]
+            next_pix = pew.Pix.from_text(selectedText)
             yield from change(screen, pix, next_pix, x, -1)
             hold_keys()
             pix = next_pix
@@ -80,6 +83,15 @@ def menugen(screen, entries):
         x = next(animation)
         yield selected
         yield selected
+        if selected >= len(entries) or entries[selected] != selectedText:
+            try:
+                selected = entries.index(selectedText)
+            except ValueError:
+                if selected >= len(entries):
+                    selected = len(entries) - 1
+                selectedText = entries[selected]
+                pix = pew.Pix.from_text(selectedText)
+                animation = scroll(screen, pix)
 
 
 def menu(entries):

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ def hold_keys():
     return keys
 
 
-def menugen(screen, entries):
+def menugen(screen, entries, selected=0):
     try:
         while pew.keys():
             pew.tick(1/24)
@@ -47,7 +47,6 @@ def menugen(screen, entries):
         pass
     brightness = 7
     pew.brightness(brightness)
-    selected = 0
     selectedText = entries[selected]
     pix = pew.Pix.from_text(selectedText)
     x = 0

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import time
 import pew
 
 
-def scroll(pix, dx=1):
+def scroll(screen, pix, dx=1):
     x = 0
     while True:
         for x in range(x, pix.width, dx):
@@ -14,13 +14,15 @@ def scroll(pix, dx=1):
         x = -8
 
 
-def change(pix, next_pix, x, dy):
+def change(screen, pix, next_pix, x, dy):
     for y in range(1, 1 + 8 * dy, dy):
         screen.box(0)
         screen.blit(pix, -x, y)
         screen.blit(next_pix, 0, y - 7 * dy)
         yield
 
+
+hold = 0
 
 def hold_keys():
     global hold
@@ -37,13 +39,18 @@ def hold_keys():
     return keys
 
 
-def menu(entries):
+def menugen(screen, entries):
+    try:
+        while pew.keys():
+            pew.tick(1/24)
+    except pew.GameOver:
+        pass
     brightness = 7
     pew.brightness(brightness)
     selected = 0
     pix = pew.Pix.from_text(entries[selected])
     x = 0
-    animation = scroll(pix)
+    animation = scroll(screen, pix)
     while True:
         keys = hold_keys()
         if keys & pew.K_O:
@@ -57,37 +64,28 @@ def menu(entries):
         if keys & pew.K_UP:
             selected = (selected - 1) % len(entries)
             next_pix = pew.Pix.from_text(entries[selected])
-            yield from change(pix, next_pix, x, 1)
+            yield from change(screen, pix, next_pix, x, 1)
             hold_keys()
             pix = next_pix
-            animation = scroll(pix)
+            animation = scroll(screen, pix)
             keys = 0
         if keys & pew.K_DOWN:
             selected = (selected + 1) % len(entries)
             next_pix = pew.Pix.from_text(entries[selected])
-            yield from change(pix, next_pix, x, -1)
+            yield from change(screen, pix, next_pix, x, -1)
             hold_keys()
             pix = next_pix
-            animation = scroll(pix)
+            animation = scroll(screen, pix)
             keys = 0
         x = next(animation)
         yield selected
         yield selected
 
 
-pew.init()
-while True:
-    hold = 0
+def menu(entries):
     screen = pew.Pix()
-    files = [name[:-3] for name in os.listdir()
-             if name.endswith('.py') and name != 'main.py']
-    m = menu(files)
+    m = menugen(screen, entries)
     selected = 0
-    try:
-        while pew.keys():
-            pew.tick(1/24)
-    except pew.GameOver:
-        pass
     while True:
         try:
             selected = next(m)
@@ -97,13 +95,20 @@ while True:
         pew.tick(1/24)
     screen.box(0)
     pew.show(screen)
-    game = files[selected]
-    del screen
-    del m
-    del files
-    try:
-        __import__(game)
-    except pew.GameOver:
-        pass
-    del sys.modules[game]
+    return selected
+
+
+if __name__ == '__main__':
+    pew.init()
+    while True:
+        files = [name[:-3] for name in os.listdir()
+                 if name.endswith('.py') and name != 'main.py']
+        selected = menu(files)
+        game = files[selected]
+        del files
+        try:
+            __import__(game)
+        except pew.GameOver:
+            pass
+        del sys.modules[game]
 


### PR DESCRIPTION
(Continued from pewpew-game/pewpew#9)

The attached commits split the menu functionality of _main.py_ out into a module `pew_menu` that can be used by applications, e.g. for configuration, level selection, or in my case, a lobby for online players.

It exports two functions:
- `menu(entries)`: Runs the menu with the given list of strings, blocking until the user has selected one, and returns the index of the selected entry.
- `menugen(screen, entries)`: A generator that allows background processing while the menu is running, intended to be used like
```python
for selected in pew_menu.menugen(screen, entries):
	do_other_stuff()
	pew.show(screen)
	pew.tick(1/24)
```
`do_other_stuff()` may modify `entries`, and modifications appear in the menu live.

Open questions:
- All naming is up for debate.
- Should _pew_menu.py_ move elsewhere? It’s more a library than a game, but is not platform-specific.
- I plan to supply documentation once we have a consensus about the code. (I’m not sure where the documentation lives at this time, is it still in [pewpew-game/pewpew](https://github.com/pewpew-game/pewpew)?)